### PR TITLE
Added new EventReason "NoIcingaObjectCreated" for NotFound error

### DIFF
--- a/pkg/controller/alert.go
+++ b/pkg/controller/alert.go
@@ -79,8 +79,13 @@ func (b *IcingaController) handleAlert(e *events.Event) error {
 		event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.CreatingIcingaObjects)
 
 		if err := b.IsObjectExists(); err != nil {
-			event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.FailedToCreateIcingaObjects, err.Error())
-			return errors.New().WithCause(err).Internal()
+			if errors.IsNotFound(err) {
+				event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.NoIcingaObjectCreated, err.Error())
+				return nil
+			} else {
+				event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.FailedToCreateIcingaObjects, err.Error())
+				return errors.New().WithCause(err).Internal()
+			}
 		}
 		if err := b.Create(); err != nil {
 			event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.FailedToCreateIcingaObjects, err.Error())
@@ -104,8 +109,13 @@ func (b *IcingaController) handleAlert(e *events.Event) error {
 		event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.UpdatingIcingaObjects)
 
 		if err := b.IsObjectExists(); err != nil {
-			event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.FailedToUpdateIcingaObjects, err.Error())
-			return errors.New().WithCause(err).Internal()
+			if errors.IsNotFound(err) {
+				event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.NoIcingaObjectCreated, err.Error())
+				return nil
+			} else {
+				event.CreateAlertEvent(b.ctx.KubeClient, b.ctx.Resource, types.FailedToCreateIcingaObjects, err.Error())
+				return errors.New().WithCause(err).Internal()
+			}
 		}
 
 		if err := b.Update(); err != nil {

--- a/pkg/controller/event/create.go
+++ b/pkg/controller/event/create.go
@@ -44,6 +44,10 @@ func CreateAlertEvent(kubeClient clientset.Interface, alert *aci.Alert, reason t
 		event.Reason = reason.String()
 		event.Message = fmt.Sprintf(`failed to create Icinga objects. Error: %v`, additionalMessage)
 		event.Type = kapi.EventTypeWarning
+	case types.NoIcingaObjectCreated:
+		event.Reason = reason.String()
+		event.Message = fmt.Sprintf(`no Icinga object is created. Reason: %v`, additionalMessage)
+		event.Type = kapi.EventTypeNormal
 	case types.CreatedIcingaObjects:
 		event.Reason = reason.String()
 		event.Message = fmt.Sprintf(`successfully created Icinga objects`)

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -17,6 +17,7 @@ const (
 	// Icinga objects create event list
 	CreatingIcingaObjects       EventReason = "Creating"
 	FailedToCreateIcingaObjects EventReason = "FailedToCreate"
+	NoIcingaObjectCreated       EventReason = "NoIcingaObjectCreated"
 	CreatedIcingaObjects        EventReason = "Created"
 
 	// Icinga objects update event list


### PR DESCRIPTION
If alert is set on Invalid Kubernetes object, Controller will fail to detect Kube object. Then it will create an Event with EventReason "NoIcingaObjectCreated".