### PR TITLE
Support multiple webhooks of same apiversion

### DIFF
--- a/pkg/cmds/apiserver.go
+++ b/pkg/cmds/apiserver.go
@@ -94,6 +94,7 @@ func (o APIServerOptions) Config() (*apiserver.Config, error) {
 		GenericConfig: serverConfig,
 		ExtraConfig: apiserver.ExtraConfig{
 			AdmissionHooks: o.AdmissionHooks,
+			ClientConfig:   serverConfig.ClientConfig,
 		},
 	}
 	return config, nil


### PR DESCRIPTION
Fixes 2 bugs:
- Don't reinitialize storage.
- Ensure same hooks are used in postStart to ensure initialization