### PR TITLE
If no service available, delete host

### DIFF
--- a/pkg/icinga/common.go
+++ b/pkg/icinga/common.go
@@ -58,7 +58,7 @@ func (h *commonHost) DeleteIcingaHost(kh IcingaHost) error {
 		return errors.FromErr(err).WithMessage("Can't get Icinga service").Err()
 	}
 
-	if len(respService.Results) <= 1 {
+	if len(respService.Results) == 0 {
 		resp := h.IcingaClient.Objects().Hosts("").Delete([]string{}, in).Params(param).Do()
 		if resp.Err != nil {
 			return errors.FromErr(err).WithMessage("Can't delete Icinga host").Err()


### PR DESCRIPTION
As we do not create host_check service by default, We should delete host when there is no service available.